### PR TITLE
WIP: Make TangoJS Component ES6 compatible with Polymer

### DIFF
--- a/src/tangojs-web-components.js
+++ b/src/tangojs-web-components.js
@@ -1,4 +1,6 @@
+import withTango from './util/mixins/withTango'
 import withTangoAttribute from './util/mixins/withTangoAttribute'
+import withTangoCommand from './util/mixins/withTangoCommand'
 import withPolledModel from './util/mixins/withPolledModel'
 import withReflectedAttribute from './util/mixins/withReflectedAttribute'
 import withReflectedAttributes from './util/mixins/withReflectedAttributes'
@@ -11,7 +13,6 @@ import * as fn from './util/fn'
  */
 export const components = { }
 
-
 /**
  * Utility functions for components
  */
@@ -22,7 +23,9 @@ export const util = Object.assign(
   { converters },
   {
     mixins: {
+      withTango,
       withTangoAttribute,
+      withTangoCommand,
       withPolledModel,
       withReflectedAttribute,
       withReflectedAttributes

--- a/src/tangojs-web-components.js
+++ b/src/tangojs-web-components.js
@@ -1,3 +1,4 @@
+import withTangoAttribute from './util/mixins/withTangoAttribute'
 import withPolledModel from './util/mixins/withPolledModel'
 import withReflectedAttribute from './util/mixins/withReflectedAttribute'
 import withReflectedAttributes from './util/mixins/withReflectedAttributes'
@@ -21,6 +22,7 @@ export const util = Object.assign(
   { converters },
   {
     mixins: {
+      withTangoAttribute,
       withPolledModel,
       withReflectedAttribute,
       withReflectedAttributes

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -35,17 +35,17 @@ export function registerComponent (tagName,
                                    constructor,
                                    descriptor) {
 
-  const registeredConstructor = window.document.registerElement(tagName, {
-    prototype: constructor.prototype
-  })
+  //const registeredConstructor = window.document.registerElement(tagName, {
+  //  prototype: constructor.prototype
+  //})
 
-  Object.defineProperty(registeredConstructor, 'descriptor', {
-    value: descriptor ? Object.assign({}, descriptor, { tagName }) : undefined
-  })
+  //Object.defineProperty(registeredConstructor, 'descriptor', {
+  //  value: descriptor ? Object.assign({}, descriptor, { tagName }) : undefined
+  //})
 
-  components[constructor.name] = registeredConstructor
+  //components[constructor.name] = registeredConstructor
 
-  return registeredConstructor
+  //return registeredConstructor
 }
 
 /**

--- a/src/util/mixins/withTango.js
+++ b/src/util/mixins/withTango.js
@@ -1,0 +1,55 @@
+/**
+ * Adds support for periodically polled model(s).
+ *
+ * Prototype that mixes this in should expose following functions:
+ * - onModelRead  {function(resultMap: Object): undefined}
+ * - onModelError {function(error: Object): undefined}
+ * - createProxy  {function(model: string): (AttributeProxy|DeviceProxy)}
+ * - readProxy    {function(proxy: (AttributeProxy|DeviceProxy)):
+ *                  (DeviceAttribute|DevState)}
+ *
+ * Following functions and properties are added:
+ * - proxy {Object}
+ * - onModelChange {function(model: string): undefined}
+ * - onPollPeriodChange {function(pollPeriod: number): undefined}
+ * - restartPollingTimer {function(): undefined}
+ */
+export default function (superClass) {
+  return class extends superClass {
+    constructor() {
+      super();
+    }
+
+    static get properties() {
+      return {
+	proxy: {
+          type: Object,
+	  readOnly: true,
+	  observer: 'proxyChanged'
+        },
+	model: {
+	  type: String,
+	  observer: 'onModelChange'
+	},
+	info: {
+          type: Object,
+	  readOnly: true,
+	  observer: 'infoChanged'
+        }
+      };
+    }
+
+    onModelChange(model, oldValue) {
+      if (model) {
+	console.log('model changed '+model)
+        this._setProxy(
+	  (Array.isArray(model) ? model : [model])
+            .reduce((p, m) => (p[m] = this.createProxy(m), p), {})
+	)
+      } else {
+        this._setProxy(null)
+      }
+    }
+
+  }
+}

--- a/src/util/mixins/withTangoAttribute.js
+++ b/src/util/mixins/withTangoAttribute.js
@@ -133,8 +133,11 @@ export default function (superClass) {
 
     updateValueAndQuality (value, quality) {
       this.qualityColor = this.getQualityColor(quality)
-      if(this.precision)
+      if(this.precision){
         this.value = value.toFixed(this.precision)
+      } else {
+        this.value = value
+      }
     }
 
     getQualityColor (quality) {

--- a/src/util/mixins/withTangoAttribute.js
+++ b/src/util/mixins/withTangoAttribute.js
@@ -1,0 +1,108 @@
+
+/**
+ * Adds support for periodically polled model(s).
+ *
+ * Prototype that mixes this in should expose following functions:
+ * - onModelRead  {function(resultMap: Object): undefined}
+ * - onModelError {function(error: Object): undefined}
+ * - createProxy  {function(model: string): (AttributeProxy|DeviceProxy)}
+ * - readProxy    {function(proxy: (AttributeProxy|DeviceProxy)):
+ *                  (DeviceAttribute|DevState)}
+ *
+ * Following functions and properties are added:
+ * - proxy {Object}
+ * - onModelChange {function(model: string): undefined}
+ * - onPollPeriodChange {function(pollPeriod: number): undefined}
+ * - restartPollingTimer {function(): undefined}
+ */
+export default function (superClass) {
+  return class extends superClass {
+    constructor() {
+      super();
+
+      if (!this.createProxy) {
+        console.warn('Mixing prototype lacks \'createProxy\' method.')
+      }
+
+      if (!this.readProxy) {
+        console.warn('Mixing prototype lacks \'readProxy\' method.')
+      }
+
+      if (!this.onModelRead) {
+        this.onModelRead = function () {}
+      }
+
+      if (!this.onModelError) {
+        this.onModelError = function (error) {
+          console.error(error)
+        }
+      }
+      const timer = Symbol.for('timer')
+      
+      //const proxy = Symbol.for('proxy')
+    }
+
+    
+
+    static get properties() {
+      return {
+	proxy: {
+          type: Object,
+	  readOnly: true,
+        },
+	model: {
+	  type: String,
+	  observer: 'onModelChange'
+	},
+	pollperiod: {
+	  type: Number,
+	  observer: 'onPollPeriodChange'
+	}
+      };
+    }
+
+    onModelChange(model, oldValue) {
+      if (model) {
+        this._setProxy(
+	  (Array.isArray(model) ? model : [model])
+            .reduce((p, m) => (p[m] = this.createProxy(m), p), {})
+	)
+        this.restartPollingTimer()
+      } else {
+        this.stopPollingTimer()
+      }
+    }
+
+    onPollPeriodChange(newValue, oldValue) {
+      if (this.proxy) {
+        this.restartPollingTimer()
+      }
+    }
+
+    restartPollingTimer() {
+
+      this.stopPollingTimer()
+
+      this.timer = setInterval(() => {
+        const promisedResults = Object
+          .keys(this.proxy)
+          .map(m => this.readProxy(this.proxy[m]).then(x => [m, x]))
+
+        Promise.all(promisedResults)
+          .then(results => {
+            const resultsMap = results.reduce(
+              (acc, [m, x]) => (acc[m] = x, acc),
+              {})
+            this.onModelRead(resultsMap)
+          })
+          .catch(error => {
+            this.onModelError(error)
+          })
+      }, this.pollPeriod) // FIXME: poolPeriod may be stored in mixin closure.
+    }
+
+    stopPollingTimer() {
+      clearInterval(this.timer)
+    }
+  }
+}

--- a/src/util/mixins/withTangoAttribute.js
+++ b/src/util/mixins/withTangoAttribute.js
@@ -39,7 +39,6 @@ export default function (superClass) {
       }
       const timer = Symbol.for('timer')
       
-      //const proxy = Symbol.for('proxy')
     }
 
     
@@ -54,8 +53,9 @@ export default function (superClass) {
 	  type: String,
 	  observer: 'onModelChange'
 	},
-	pollperiod: {
+	pollPeriod: {
 	  type: Number,
+	  value: 1000,
 	  observer: 'onPollPeriodChange'
 	}
       };
@@ -63,6 +63,7 @@ export default function (superClass) {
 
     onModelChange(model, oldValue) {
       if (model) {
+	console.log('model changed '+model)
         this._setProxy(
 	  (Array.isArray(model) ? model : [model])
             .reduce((p, m) => (p[m] = this.createProxy(m), p), {})
@@ -75,12 +76,31 @@ export default function (superClass) {
 
     onPollPeriodChange(newValue, oldValue) {
       if (this.proxy) {
+	console.log('poll period changed '+newValue)
         this.restartPollingTimer()
       }
     }
 
-    restartPollingTimer() {
+    createProxy(model) {
+      const [_, devname, name] = model.match(/^(.+)\/([A-Za-z0-9_]+)$/)
+      console.log('creating a proxy')
+      return new tangojs.core.api.AttributeProxy(devname, name)
+    }
 
+    readProxy(proxy) {
+      console.log('reading a proxy. argument: '+proxy+', this.proxy '+this.proxy)
+      return proxy.read()
+    }
+
+    onModelRead (deviceAttributes) {
+      const attribute = deviceAttributes[this.model];
+      this.attribute = attribute.value;
+      this.attributeValue = attribute.value;
+    }
+
+	  
+    restartPollingTimer() {
+      console.log('restartPolling with period '+this.pollPeriod)
       this.stopPollingTimer()
 
       this.timer = setInterval(() => {

--- a/src/util/mixins/withTangoCommand.js
+++ b/src/util/mixins/withTangoCommand.js
@@ -29,18 +29,24 @@ export default function (superClass) {
       };
     }
 
-    onModelChange(model) {
+    createProxy(model) {
       const [_, devname, name] = model.match(/^(.+)\/([A-Za-z0-9_]+)$/)
       console.log('creating a proxy')
-      this._setProxy( new tangojs.core.api.CommandProxy(devname, name))
-      // update the info
-      // Probably to refactor
-      this.proxy.get_info().then(i => this._setInfo(i))
+      return new tangojs.core.api.CommandProxy(devname, name)
+    }
+
+    proxyChanged(proxy){
+      this.proxy[this.model].get_info().then(i => this._setInfo(i))
+    }
+
+    infoChanged(info) { 
+      this.name = info.cmd_name
     }
 
     execute(event){
       const devDataIn = new tangojs.core.api.DeviceData(this.arguments)
-      this.proxy.inout(devDataIn).then(devDataOut => {
+      console.log('command proxy:'+this.proxy)
+      this.proxy[this.model].inout(devDataIn).then(devDataOut => {
 	// What to do?
 	//this.dispatchEvent(new CommandButtonResultEvent(devDataOut))
       })
@@ -48,8 +54,4 @@ export default function (superClass) {
 
   }
 }
-
-
-
-
 

--- a/src/util/mixins/withTangoCommand.js
+++ b/src/util/mixins/withTangoCommand.js
@@ -1,0 +1,55 @@
+import withTango from './withTango'
+/**
+ * Adds support for periodically polled model(s).
+ *
+ * Prototype that mixes this in should expose following functions:
+ * - onModelRead  {function(resultMap: Object): undefined}
+ * - onModelError {function(error: Object): undefined}
+ * - createProxy  {function(model: string): (AttributeProxy|DeviceProxy)}
+ * - readProxy    {function(proxy: (AttributeProxy|DeviceProxy)):
+ *                  (DeviceAttribute|DevState)}
+ *
+ * Following functions and properties are added:
+ * - proxy {Object}
+ * - onModelChange {function(model: string): undefined}
+ * - onPollPeriodChange {function(pollPeriod: number): undefined}
+ * - restartPollingTimer {function(): undefined}
+ */
+export default function (superClass) {
+  return class extends withTango(superClass) {
+    constructor() {
+      super();
+    }
+
+    static get properties() {
+      return {
+	arguments: {
+	  type: String,
+	},
+      };
+    }
+
+    onModelChange(model) {
+      const [_, devname, name] = model.match(/^(.+)\/([A-Za-z0-9_]+)$/)
+      console.log('creating a proxy')
+      this._setProxy( new tangojs.core.api.CommandProxy(devname, name))
+      // update the info
+      // Probably to refactor
+      this.proxy.get_info().then(i => this._setInfo(i))
+    }
+
+    execute(event){
+      const devDataIn = new tangojs.core.api.DeviceData(this.arguments)
+      this.proxy.inout(devDataIn).then(devDataOut => {
+	// What to do?
+	//this.dispatchEvent(new CommandButtonResultEvent(devDataOut))
+      })
+    }	    
+
+  }
+}
+
+
+
+
+

--- a/src/util/mixins/withTangoDevice.js
+++ b/src/util/mixins/withTangoDevice.js
@@ -1,0 +1,33 @@
+import withTango from "./withTango"
+/**
+ * Adds support for periodically polled model(s).
+ *
+ * Prototype that mixes this in should expose following functions:
+ * - onModelRead  {function(resultMap: Object): undefined}
+ * - onModelError {function(error: Object): undefined}
+ * - createProxy  {function(model: string): (AttributeProxy|DeviceProxy)}
+ * - readProxy    {function(proxy: (AttributeProxy|DeviceProxy)):
+ *                  (DeviceAttribute|DevState)}
+ *
+ * Following functions and properties are added:
+ * - proxy {Object}
+ * - onModelChange {function(model: string): undefined}
+ * - onPollPeriodChange {function(pollPeriod: number): undefined}
+ * - restartPollingTimer {function(): undefined}
+ */
+export default function (superClass) {
+  return class extends withTango(superClass) {
+    constructor() {
+      super();
+    }
+
+    createProxy(model) {
+      console.log('creating a proxy')
+      const proxy =  new tangojs.core.api.DeviceProxy(model)
+      // update the info
+      // Probably to refactor
+      proxy.get_info().then(i => this._setInfo(i))
+      return proxy
+    }
+  }
+}


### PR DESCRIPTION
Based on ES6 syntax this branch aim to upgrade the existing code. I choose the support of the polymer project but not as direct dependency. The web component using the new ES6 TangoJS mixin should manage themselves the data binding, previous role of the reflected attribute mixin.

3 new mixins are introduced:
* withTango: a basic mixin implementing the common properties and behaviour like model, proxy, info ...
* withTangoAttribute: a mixin to make any webcomponent accepting a tango attribute as model. It brings the polling system as well. This is a replacement of both the Poll and part of the reflected attribute mixins
* withTangoCommand: a mixin to make any webcomponent accepting a tango command as a model. The code has been extracted the tangojs-command-button.

Example of usage:
```javascript
class TangojsLabel extends tangojs.web.util.mixins.withTangoAttribute(Polymer.Element){
}
```
see the full example [tangojs-label](https://github.com/hardion/tangojs-label/tree/devel)
